### PR TITLE
exports: use reent declaration from sys/reent.h

### DIFF
--- a/source/exports.c
+++ b/source/exports.c
@@ -14,6 +14,7 @@
 #include <time.h>
 #include <assert.h>
 #include <elf.h>
+#include <sys/reent.h>
 
 #include "common.h"
 #include "solder.h"
@@ -186,8 +187,6 @@ int solder_set_main_exports(const solder_export_t *exp, const int numexp) {
    this is the bare minimum necessary to run testlib_cpp with local libstdc++ and a bunch of extras
    if you want to go the "link libstdc++ to main" route, you'll have to provide many C++ exports instead
 */
-
-extern void *__getreent(void);
 
 const solder_export_t solder_default_exports[] __attribute__((used)) = {
   SOLDER_EXPORT_SYMBOL(__getreent),


### PR DESCRIPTION
Should fix compiler error:
```
/home/runner/work/xash3d-fwgs/xash3d-fwgs/libsolder/source/exports.c:190:14: error: conflicting types for '__getreent'; have 'void *(void)'
  190 | extern void *__getreent(void);
      |              ^~~~~~~~~~
In file included from /opt/devkitpro/devkitA64/aarch64-none-elf/include/stdlib.h:18,
                 from /home/runner/work/xash3d-fwgs/xash3d-fwgs/libsolder/source/exports.c:1:
/opt/devkitpro/devkitA64/aarch64-none-elf/include/sys/reent.h:781:19: note: previous declaration of '__getreent' with type 'struct _reent *(void)'
  781 |   struct _reent * __getreent (void);
```

https://github.com/FWGS/xash3d-fwgs/actions/runs/4968716815/jobs/8891483529